### PR TITLE
Fix image loading for GitHub stats

### DIFF
--- a/src/components/Pages/Home.tsx
+++ b/src/components/Pages/Home.tsx
@@ -30,6 +30,7 @@ const Home: React.FC = () => (
               <img
                 src="https://github-readme-stats.vercel.app/api?username=thomas-nicholson&show_icons=true&theme=transparent"
                 alt="GitHub stats"
+                loading="lazy"
                 className="max-w-full h-auto"
               />
             </div>
@@ -37,6 +38,7 @@ const Home: React.FC = () => (
               <img
                 src="https://github-readme-streak-stats.herokuapp.com/?user=thomas-nicholson&theme=transparent"
                 alt="GitHub streak stats"
+                loading="lazy"
                 className="max-w-full h-auto"
               />
             </div>
@@ -52,6 +54,7 @@ const Home: React.FC = () => (
             <img
               src="https://ghchart.rshah.org/thomas-nicholson"
               alt="GitHub contribution graph"
+              loading="lazy"
               className="max-w-full h-auto"
             />
           </div>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to GitHub stats and streak images on the homepage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865e0766f5c8328a8871120d86929bc