### PR TITLE
Add dark mode toggle and filters

### DIFF
--- a/__tests__/ProjectsFilter.test.tsx
+++ b/__tests__/ProjectsFilter.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Projects from '../src/components/Pages/Projects';
+
+it('filters projects by selected technology', () => {
+  render(
+    <MemoryRouter>
+      <Projects />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText('Money Talks')).toBeInTheDocument();
+  const reactCheckbox = screen.getByLabelText('React');
+  fireEvent.click(reactCheckbox);
+  expect(screen.queryByText('Money Talks')).toBeNull();
+  expect(screen.getByText('Deja Do')).toBeInTheDocument();
+  expect(screen.getByText('AI Chat Interface')).toBeInTheDocument();
+});

--- a/__tests__/ThemeToggle.test.tsx
+++ b/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Layout from '../src/components/Layout/Layout';
+
+it('toggles dark mode class on html element', () => {
+  render(
+    <MemoryRouter>
+      <Layout>
+        <div>content</div>
+      </Layout>
+    </MemoryRouter>
+  );
+  const button = screen.getByRole('button', { name: /toggle dark mode/i });
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+  fireEvent.click(button);
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome, faLaptopCode, faBook, faEnvelope } from '@fortawesome/free-solid-svg-icons';
+import useTheme from '../../hooks/useTheme';
 
 
 interface LayoutProps {
@@ -9,8 +10,10 @@ interface LayoutProps {
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
+  const [theme, toggleTheme] = useTheme();
+
   return (
-    <div className="container mx-auto text-black bg-white">
+    <div className="container mx-auto min-h-screen text-gray-800 bg-white dark:bg-gray-900 dark:text-gray-100">
       <nav className="flex flex-wrap justify-between p-4">
         <div className="hidden lg:flex lg:items-center lg:w-auto">
           <div className="text-sm lg:flex-grow">
@@ -20,6 +23,13 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             <Link to="/contact" className="lg:inline-block lg:mt-0 px-4 py-2 hover:underline">Contact</Link>
           </div>
         </div>
+        <button
+          aria-label="Toggle Dark Mode"
+          onClick={toggleTheme}
+          className="ml-auto p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+        >
+          {theme === 'dark' ? 'Light' : 'Dark'} Mode
+        </button>
         <div className="fixed bottom-0 left-0 right-0 bg-white border-t lg:hidden z-50">
           <div className="flex h-full">
             <Link to="/" className="flex-1 flex items-center justify-center py-3 text-gray-700 hover:text-gray-900 hover:bg-gray-100">

--- a/src/components/Pages/Contact.tsx
+++ b/src/components/Pages/Contact.tsx
@@ -1,21 +1,35 @@
-import React from "react";
+import React, { useState } from "react";
 
 const Contact: React.FC = () => {
+  const [form, setForm] = useState({ name: "", email: "", message: "" });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const subject = encodeURIComponent(`Portfolio Contact from ${form.name}`);
+    const body = encodeURIComponent(`${form.message}\n\nFrom: ${form.name}\nEmail: ${form.email}`);
+    window.location.href = `mailto:thomas@example.com?subject=${subject}&body=${body}`;
+  };
+
   return (
-    <div className="min-h-screen py-12">
+    <div className="min-h-screen py-12 dark:bg-gray-900 dark:text-gray-100">
       <div className="max-w-4xl mx-auto px-4">
-        <div className="bg-white rounded-lg shadow-lg p-8">
-          <h1 className="text-4xl font-bold text-gray-800 mb-8 text-center">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+          <h1 className="text-4xl font-bold text-gray-800 dark:text-gray-100 mb-8 text-center">
             Get in Touch
           </h1>
 
           <div className="max-w-lg mx-auto">
-            <h2 className="text-2xl font-bold text-gray-800 mb-6">
+            <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-6">
               Contact Information
             </h2>
-            <div className="space-y-6">
-              <div>
-                <h3 className="font-semibold text-gray-700 mb-2">Email</h3>
+          <div className="space-y-6">
+            <div>
+              <h3 className="font-semibold text-gray-700 mb-2">Email</h3>
                 <a
                   href="mailto:thomas@example.com"
                   className="text-blue-600 hover:text-blue-800"
@@ -46,6 +60,46 @@ const Contact: React.FC = () => {
                 </a>
               </div>
             </div>
+          </div>
+            <form onSubmit={handleSubmit} className="space-y-4 mt-8">
+              <div>
+                <label htmlFor="name" className="block mb-1 font-semibold">Name</label>
+                <input
+                  id="name"
+                  name="name"
+                  type="text"
+                  value={form.name}
+                  onChange={handleChange}
+                  className="w-full p-2 border rounded dark:bg-gray-700"
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="email" className="block mb-1 font-semibold">Email</label>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  value={form.email}
+                  onChange={handleChange}
+                  className="w-full p-2 border rounded dark:bg-gray-700"
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="message" className="block mb-1 font-semibold">Message</label>
+                <textarea
+                  id="message"
+                  name="message"
+                  rows={4}
+                  value={form.message}
+                  onChange={handleChange}
+                  className="w-full p-2 border rounded dark:bg-gray-700"
+                  required
+                />
+              </div>
+              <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Send</button>
+            </form>
           </div>
         </div>
       </div>

--- a/src/components/Pages/Home.tsx
+++ b/src/components/Pages/Home.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 
 const Home: React.FC = () => (
-  <div className="min-h-screen">
+  <div className="min-h-screen dark:bg-gray-900 dark:text-gray-100">
     <div className="max-w-4xl mx-auto p-8">
       <div className="text-center mb-16">
-        <h1 className="text-5xl font-bold text-gray-800 mb-4">
+        <h1 className="text-5xl font-bold text-gray-800 dark:text-gray-100 mb-4">
           Thomas Nicholson
         </h1>
         <p className="text-xl text-gray-600">Full-Stack Software Engineer</p>
       </div>
 
       <div className="space-y-8 mb-8">
-        <div className="bg-white rounded-lg shadow-lg p-8">
-          <h2 className="text-2xl font-bold text-gray-800 mb-4">About Me</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+          <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">About Me</h2>
           <p className="text-gray-600 leading-relaxed">
             I'm a passionate software developer with expertise in building
             scalable web applications. My focus is on creating elegant solutions
@@ -21,8 +21,8 @@ const Home: React.FC = () => (
           </p>
         </div>
 
-        <div className="bg-white rounded-lg shadow-lg p-4 sm:p-8">
-          <h2 className="text-2xl font-bold text-gray-800 mb-6 text-center">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 sm:p-8">
+          <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-6 text-center">
             GitHub Activity
           </h2>
           <div className="flex flex-col lg:grid lg:grid-cols-2 gap-6">
@@ -62,8 +62,8 @@ const Home: React.FC = () => (
       </div>
 
       <div className="grid md:grid-cols-2 gap-8">
-        <div className="bg-white rounded-lg shadow-lg p-8">
-          <h2 className="text-2xl font-bold text-gray-800 mb-4">Skills</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+          <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">Skills</h2>
           <div className="grid grid-cols-2 gap-4">
             <div>
               <h3 className="font-semibold text-gray-700 mb-2">Frontend</h3>
@@ -89,8 +89,8 @@ const Home: React.FC = () => (
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-lg p-8">
-          <h2 className="text-2xl font-bold text-gray-800 mb-4">Experience</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+          <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">Experience</h2>
           <div className="space-y-4">
             <div>
               <h3 className="font-semibold text-gray-700">

--- a/src/components/Pages/Projects.tsx
+++ b/src/components/Pages/Projects.tsx
@@ -50,6 +50,21 @@ const Projects: React.FC = () => {
   ];
 
   const [projects] = useState(initialProjects);
+  const [selectedTech, setSelectedTech] = useState<string[]>([]);
+
+  const allTech = Array.from(new Set(initialProjects.flatMap((p) => p.tech)));
+
+  const handleTechChange = (tech: string) => {
+    setSelectedTech((prev) =>
+      prev.includes(tech) ? prev.filter((t) => t !== tech) : [...prev, tech]
+    );
+  };
+
+  const filteredProjects = projects.filter(
+    (project) =>
+      selectedTech.length === 0 ||
+      selectedTech.every((tech) => project.tech.includes(tech))
+  );
   // const [isDragging, setIsDragging] = useState(false);
 
   // const handleDragStart = (e: React.DragEvent<HTMLDivElement>, project: any) => {
@@ -82,19 +97,30 @@ const Projects: React.FC = () => {
 
 
   return (
-    <div className="min-h-screen py-12">
+    <div className="min-h-screen py-12 dark:bg-gray-900 dark:text-gray-100">
       <div className="max-w-6xl mx-auto px-4">
-        <h1 className="text-4xl font-bold text-gray-800 mb-8 text-center">
+        <h1 className="text-4xl font-bold text-gray-800 dark:text-gray-100 mb-8 text-center">
           Projects
         </h1>
-        <div
-          className="grid md:grid-cols-2 lg:grid-cols-3 gap-8"
-          
-        >
-          {projects.map((project, index) => (
+        <div className="mb-6">
+          <span className="font-semibold mr-2">Filter by tech:</span>
+          {allTech.map((tech) => (
+            <label key={tech} className="mr-4">
+              <input
+                type="checkbox"
+                className="mr-1"
+                checked={selectedTech.includes(tech)}
+                onChange={() => handleTechChange(tech)}
+              />
+              {tech}
+            </label>
+          ))}
+        </div>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {filteredProjects.map((project, index) => (
             <div
               key={project.title}
-              className="bg-white rounded-lg shadow-lg overflow-hidden relative group"
+              className="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden relative group"
               // draggable
               // onDragStart={(e) => handleDragStart(e, project)}
               // onDragOver={handleDragOver}
@@ -136,7 +162,7 @@ const Projects: React.FC = () => {
                 )}
               </div>
               <div className="p-6">
-                <h2 className="text-2xl font-bold text-gray-800 mb-2">
+                <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-2">
                   {project.title}
                 </h2>
                 <p className="text-gray-600 mb-4">{project.description}</p>
@@ -184,14 +210,14 @@ const Projects: React.FC = () => {
           ))}
         </div>
 
-        <h2 className="text-3xl font-bold text-gray-800 mb-8 mt-16 text-center">
+        <h2 className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-8 mt-16 text-center">
           Archived Projects
         </h2>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
           {archivedProjects.map((project) => (
             <div
               key={project.title}
-              className="bg-white rounded-lg shadow-lg overflow-hidden"
+              className="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden"
             >
               <div className="relative">
                 <img
@@ -207,7 +233,7 @@ const Projects: React.FC = () => {
               </div>
               <div className="p-6">
                 <div className="flex justify-between items-center mb-2">
-                  <h2 className="text-2xl font-bold text-gray-800">
+                  <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100">
                     {project.title}
                   </h2>
                   <span className="text-sm text-gray-500">{project.year}</span>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const useTheme = (): [Theme, () => void] => {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return [theme, toggleTheme];
+};
+
+export default useTheme;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ export default {
     './src/**/*.tsx', // or './src/**/*.tsx' if using TypeScript
     // more paths where Tailwind classes may be used
   ],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- implement a `useTheme` hook and add toggle button to Layout
- enable dark mode in Tailwind
- apply dark mode styles to pages
- add technology filter UI to Projects page
- expand Contact page with a client-only contact form
- create tests for theme toggle and project filtering
- stub `window.matchMedia` in Jest setup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865e81613f883289daea8996b3fbe16