### PR TITLE
Fix dark mode colors for mobile nav

### DIFF
--- a/__tests__/Layout.test.tsx
+++ b/__tests__/Layout.test.tsx
@@ -13,3 +13,16 @@ test('renders children inside Layout', () => {
   );
   expect(screen.getByText('Test Content')).toBeInTheDocument();
 });
+
+test('mobile nav includes dark mode classes', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <Layout>
+        <div>Content</div>
+      </Layout>
+    </MemoryRouter>
+  );
+  const mobileNav = container.querySelector('div.fixed.bottom-0');
+  expect(mobileNav).not.toBeNull();
+  expect(mobileNav?.className).toContain('dark:bg-gray-800');
+});

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -30,18 +30,30 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         >
           {theme === 'dark' ? 'Light' : 'Dark'} Mode
         </button>
-        <div className="fixed bottom-0 left-0 right-0 bg-white border-t lg:hidden z-50">
+        <div className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t dark:border-gray-700 lg:hidden z-50">
           <div className="flex h-full">
-            <Link to="/" className="flex-1 flex items-center justify-center py-3 text-gray-700 hover:text-gray-900 hover:bg-gray-100">
+            <Link
+              to="/"
+              className="flex-1 flex items-center justify-center py-3 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
               <FontAwesomeIcon icon={faHome} size="lg" />
             </Link>
-            <Link to="/projects" className="flex-1 flex items-center justify-center text-gray-700 hover:text-gray-900 hover:bg-gray-100">
+            <Link
+              to="/projects"
+              className="flex-1 flex items-center justify-center text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
               <FontAwesomeIcon icon={faLaptopCode} size="lg" />
             </Link>
-            <Link to="/blog" className="flex-1 flex items-center justify-center text-gray-700 hover:text-gray-900 hover:bg-gray-100">
+            <Link
+              to="/blog"
+              className="flex-1 flex items-center justify-center text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
               <FontAwesomeIcon icon={faBook} size="lg" />
             </Link>
-            <Link to="/contact" className="flex-1 flex items-center justify-center text-gray-700 hover:text-gray-900 hover:bg-gray-100">
+            <Link
+              to="/contact"
+              className="flex-1 flex items-center justify-center text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
               <FontAwesomeIcon icon={faEnvelope} size="lg" />
             </Link>
           </div>


### PR DESCRIPTION
## Summary
- update mobile navbar styling for dark mode
- ensure bottom nav has dark mode classes
- test mobile nav dark class

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686610706ba08328ab4eeb0359c4f20f